### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2568,7 +2568,7 @@
     - name: VoiceXML API Class Library
       href: https://msdn.microsoft.com/en-us/library/office/dn435961.aspx
   - name: Unified Communications Web API 2.0 (Skype)
-    href: https://docs.microsoft.com/en-us/skype-sdk/ucwa/unifiedcommunicationswebapi2_0  
+    href: /skype-sdk/ucwa/unifiedcommunicationswebapi2_0  
   - name: Technical articles
     href: technical-articles/lync-2013-technical-articles.md
     items:


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
