### PR TITLE
[METADATA UPDATE][Merge by 2024-02-10] Retiring the ms.prod and ms.technology metadata attributes from the Learn platform (values moving to ms.service)

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -38,25 +38,27 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
+      "ms.subservice": "sdk",
+      "ms.service": "lync",
       "feedback_system": "Standard",
     "breadcrumb_path": "/lync/breadcrumb/toc.json",
     "extendBreadcrumb": true,
 	  "uhfHeaderId": "MSDocsHeader-Dev_Office",
 	   "ms.suite": "office",
-	   "ms.prod" : "lync",
 	   "ms.author": "o365devx",
 	   "author": "o365devx",
 	   "ms.topic": "conceptual",
-	   "ms.technology": "sdk",
 	   "contributors_to_exclude": ["nivnar"] 
     },
     "fileMetadata": {
+      "ms.subservice": {
+        "schema/**.md": "schema",
+        "sdn-api/**.md": "sdn",
+        "sdn-interface/**.md": "sdn",
+        "technical-articles/**.md": "dev-overview"
+      },
  	 "ms.technology": 
        { 
-      "sdn-api/**.md" : "sdn",
-		 "sdn-interface/**.md" : "sdn",
-		 "schema/**.md" : "schema",
-		 "technical-articles/**.md" : "dev-overview"
        }
 	 },
     "template": [],


### PR DESCRIPTION
A Pull Request has been made from the Learn Platform's Metadata Management System. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about the purpose of these metadata updates, please contact [docs-allowlist-mgmt@microsoft.com](mailto:docs-allowlist-mgmt@microsoft.com). If you are not the correct contact for this content and repository, please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com).

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update. This includes bypassing the Repository's Branch Policy, including if Review Required is enabled. Please notify [Metadata-Management@microsoft.com](mailto:Metadata-Management@microsoft.com) if you have questions or concerns or would like Pull Requests for metadata updates to merge automatically in future.

Fixing[#930792 Remove ms.technology = schema paired with ms.prod = lync. Replaced by ms.subservice = schema paired with ms.service = lync](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/930792)
Fixing[#930793 Remove ms.technology = sdk paired with ms.prod = lync. Replaced by ms.subservice = sdk paired with ms.service = lync](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/930793)
Fixing[#930794 Remove ms.technology = sdn paired with ms.prod = lync. Replaced by ms.subservice = sdn paired with ms.service = lync](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/930794)
Fixing[#930795 Remove ms.technology = dev-overview paired with ms.prod = lync. Replaced by ms.subservice = dev-overview paired with ms.service = lync](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/930795)

Summary
In Germanium, the ms.prod and ms.technology metadata attributes will be retired from the Learn platform and values will be consolidated into ms.service and ms.subservice for reporting on content by product.

C+E Skilling Content Architecture manages internal, business-facing taxonomies that enable reporting on key metrics for content published on Microsoft Learn. Authors manually apply values from these taxonomies to populate metadata attributes.
Two of these taxonomies are [ms.prod/ms.technology](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#msprod) and [ms.service/ms.subservice](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#msservice). "ms.prod" and "ms.service" were distinctions carried over from legacy systems that predated the Learn platform, intended to differentiate on-prem products from cloud services.
We plan to rename the attributes from ms.service and ms.subservice in a future semester.
Why are we making this change?

For the business: Accuracy of reporting metadata directly impacts the accuracy of content analytics, so it's important that related taxonomies reflect the current state of the business. Most product taxonomies within Microsoft no longer distinguish between "on-prem" and "cloud service."
For content authors: We eliminate the need to choose between two similar attributes when applying reporting metadata to content or filtering reports.
For engineers, data scientists, and taxonomists: Simplifying and reducing underlying metadata attributes reduces the cost and complexity required to extend metadata capabilities on the platform.
How does this affect me?

Once changes to reporting metadata are merged, dashboards and reports maintained by Skilling Insights & Intelligence will reflect new values. If you've been using ms.prod/ms.technology filters, you'll switch to ms.service/ms.subservice filters in those dashboards and reports.
If you have custom dashboards or Kusto queries, you might need to update those as well.
Frequently Asked Questions
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.

For Git Repos with a permissioned Service Account, we open the PR from our Document Build Service Account.
For Git Repos that we either do not have Service Account permission for or the repo is in Azure Repos (ADO) we open the Pull Requests in an automated way with the PR creator as the Repo owner.
How can I revert a Pull Request that has been merged and created an unexpected issue? Whether a PR has been merged manually or automatically, you can revert it if an issue arises. See [Reverting a pull request - GitHub Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request).